### PR TITLE
Support for Markdown in notice shortcode

### DIFF
--- a/layouts/shortcodes/notice.html
+++ b/layouts/shortcodes/notice.html
@@ -1,2 +1,2 @@
 {{ $_hugo_config := `{ "version": 1 }` }}
-<div class="notices {{ .Get 0 }}" {{ if len .Params | eq 2 }} id="{{ .Get 1 }}" {{ end }}><p>{{ .Inner }}</p></div>
+<div class="notices {{ .Get 0 }}" {{ if len .Params | eq 2 }} id="{{ .Get 1 }}" {{ end }}><p>{{ .Inner | markdownify }}</p></div>


### PR DESCRIPTION
Support Markdown in the notice shortcode - as example for links