### PR TITLE
Fix '.File.UniqueID on zero object' warning

### DIFF
--- a/layouts/partials/default.html
+++ b/layouts/partials/default.html
@@ -80,8 +80,12 @@
 {{ $currentNode := .currentnode }}
 {{with .sect}}
 {{safeHTML .Params.head}}
+{{ $fileUniqueID := "" }}
+{{ with .File }}{{ $fileUniqueID = .UniqueID }}{{ end }}
+{{ $currentNodeFileUniqueID := "" }}
+{{ with $currentNode.File }}{{ $currentNodeFileUniqueID = .UniqueID }}{{ end }}
 <li data-nav-id="{{.Permalink}}" title="{{.Title}}" class="sidelist
-  {{if eq .File.UniqueID $currentNode.File.UniqueID}}active{{end}}">
+  {{if eq $fileUniqueID $currentNodeFileUniqueID}}active{{end}}">
   <a href="{{.Permalink}}">
     {{safeHTML .Params.Pre}}{{or .Params.menuTitle .LinkTitle .Title}}{{safeHTML .Params.Post}}
   </a>


### PR DESCRIPTION
This PR aims to fix the
```
WARN 2020/03/11 16:12:02 .File.UniqueID on zero object. Wrap it in if or with: {{ with .File }}{{ .UniqueID }}{{ end }}
```
message with the latest Hugo version.