### PR TITLE
Avoid printing unnecessary sections in sidelist

### DIFF
--- a/assets/css/style.css
+++ b/assets/css/style.css
@@ -763,7 +763,7 @@ tbody {
 
 /* side list */
 .sidelist {
-  display: none;
+  display: block;
 }
 
 li.sidelist>a {
@@ -774,18 +774,6 @@ li.sidelist>a {
 
 li.sidelist li a {
   margin: 0;
-}
-
-.sidelist.parent {
-  display: block;
-}
-
-.sidelist.parent::before {
-  display: none;
-}
-
-.sidelist.parent.active::before {
-  display: block;
 }
 
 .sidelist li.sidelist {

--- a/layouts/partials/default.html
+++ b/layouts/partials/default.html
@@ -8,8 +8,10 @@
             {{ $currentNode := . }}
             <a class="d-block h4 back-btn" href="{{ .Site.BaseURL | relLangURL }}">{{ i18n "Back-home"}}</a>
             {{range .Site.Home.Sections.ByWeight}}
-            {{ template "section-tree-nav" dict "sect" . "currentnode" $currentNode}}
-            {{end}}
+              {{ if eq . $currentNode.FirstSection }} {{/* print current section only */}}
+              {{ template "section-tree-nav" dict "sect" . "currentnode" $currentNode}}
+              {{ end }}
+            {{ end }}
           </ul>
         </div>
       </div>
@@ -79,29 +81,21 @@
 {{with .sect}}
 {{safeHTML .Params.head}}
 <li data-nav-id="{{.Permalink}}" title="{{.Title}}" class="sidelist
-  {{if .IsAncestor $currentNode }}parent{{end}}
-  {{if eq .File.UniqueID $currentNode.File.UniqueID}}active{{end}}
-  {{if .Params.alwaysopen}}parent{{end}}">
+  {{if eq .File.UniqueID $currentNode.File.UniqueID}}active{{end}}">
   <a href="{{.Permalink}}">
     {{safeHTML .Params.Pre}}{{or .Params.menuTitle .LinkTitle .Title}}{{safeHTML .Params.Post}}
   </a>
   {{ $numberOfPages := (add (len .Pages) (len .Sections)) }}
   {{ if ne $numberOfPages 0 }}
-  <ul>
-    {{ $currentNode.Scratch.Set "pages" .Pages }}
-    {{ if .Sections}}
-    {{ $currentNode.Scratch.Set "pages" (.Pages | union .Sections) }}
-    {{end}}
-    {{ $pages := ($currentNode.Scratch.Get "pages") }}
-
-    {{ range $pages.ByWeight }}
-    {{ if and .Params.hidden (not $.showhidden) }}
-    {{else}}
-    {{ template "section-tree-nav" dict "sect" . "currentnode" $currentNode }}
-    {{end}}
-    {{end}}
-  </ul>
+    <ul>
+      {{ range .Pages.ByWeight }}
+        {{ if and .Params.hidden (not $.showhidden) }}
+        {{else}}
+          {{ template "section-tree-nav" dict "sect" . "currentnode" $currentNode }}
+        {{end}}
+      {{end}}
+    </ul>
+  {{ end }}
 </li>
-{{ end }}
 {{ end }}
 {{ end }}

--- a/layouts/partials/default.html
+++ b/layouts/partials/default.html
@@ -8,7 +8,7 @@
             {{ $currentNode := . }}
             <a class="d-block h4 back-btn" href="{{ .Site.BaseURL | relLangURL }}">{{ i18n "Back-home"}}</a>
             {{range .Site.Home.Sections.ByWeight}}
-              {{ if eq . $currentNode.FirstSection }} {{/* print current section only */}}
+              {{ if eq .FirstSection $currentNode.FirstSection }} {{/* print current section only */}}
               {{ template "section-tree-nav" dict "sect" . "currentnode" $currentNode}}
               {{ end }}
             {{ end }}


### PR DESCRIPTION
Before the fix the sidelist contains lots of uncessary `li` that doens't belong to the current section.
<img width="775" alt="Screenshot 2020-03-11 16 21 12" src="https://user-images.githubusercontent.com/202578/76397168-92b83e80-63b5-11ea-8045-0f2ee7f9d6d2.png">

After the fix, sidelist now only contains the current sections.

<img width="735" alt="Screenshot 2020-03-11 16 26 12" src="https://user-images.githubusercontent.com/202578/76397180-96e45c00-63b5-11ea-9452-aa731afcedbb.png">
