### PR TITLE
use absLangUrl instead of relLangUrl for navigation links

### DIFF
--- a/layouts/partials/navigation.html
+++ b/layouts/partials/navigation.html
@@ -30,13 +30,13 @@
           </a>
           <div class="dropdown-menu">
             {{ range .Children }}
-            <a class="dropdown-item" href="{{ .URL | relLangURL }}">{{ .Name }}</a>
+            <a class="dropdown-item" href="{{ .URL | absLangURL }}">{{ .Name }}</a>
             {{ end }}
           </div>
         </li>
         {{ else }}
         <li class="nav-item">
-          <a class="nav-link text-dark" href="{{ .URL | relLangURL }}">{{ .Name }}</a>
+          <a class="nav-link text-dark" href="{{ .URL | absLangURL }}">{{ .Name }}</a>
         </li>
         {{ end }}
         {{ end }}


### PR DESCRIPTION
I've tested that this works with the following `baseURL` and `relativeURLs` conditions:

- `baseURL` is a "root" w/out a context path, and `relativeURL's = true`
- `baseURL` is a "root" w/out a context path, and `relativeURL's = false`
- `baseURL` has a context path, and `relativeURL's = true`
- `baseURL` has a context path, and `relativeURL's = false`

fixes #148 