### PR TITLE
Add local extension to header partial

### DIFF
--- a/layouts/partials/head.html
+++ b/layouts/partials/head.html
@@ -49,5 +49,11 @@
 <script src="{{ `plugins/match-height/jquery.matchHeight-min.js` | absURL }}"></script>
 
 {{ template "_internal/google_analytics.html" . }}
+  
+{{ if templates.Exists ( printf "partials/overrides/header.html" ) }}
+  {{ partial "partials/overrides/header.html" . }}
+{{ else }}
+  {{ "<!-- create /layouts/partials/overrides/header.html in your own theme or root directory to add your custom content here -->" | safeHTML }}
+{{ end }}
 
 </head>


### PR DESCRIPTION
I have a use case where I would like to add custom content before the `</head>` tag. This change implements that. Users can add locally (either in their overriding theme or in the root directory) add /layouts/partials/overrides/header.html and the content is printed at that location.

I see multiple uses for this, after `<body>`, before `</body>`... The path in templates.Exists must be run through printf for some reason.